### PR TITLE
Remove the not-FAA-recognized and horribly mislocated RCP airport

### DIFF
--- a/airports.csv
+++ b/airports.csv
@@ -2534,7 +2534,6 @@ RCE,48.6126,-123.14,Roche Harbor Airport,Friday Harbor,Washington,United States,
 RCH,11.5292,-72.9244,Almirante Padilla Airport,Ríohacha,La Guajira,Colombia,12512362,America/Bogota,,Airports,,,5413,48,,1,1
 RCL,-15.4802,167.834,,Redcliffe,,Vanuatu,23424907,Pacific/Efate,,Airports,,,2230,36,,1,1
 RCM,-20.7021,143.115,Richmond Aerodrome,Bellfield,Queensland,Australia,12510771,Australia/Brisbane,,Airports,,,5000,675,,2,1
-RCP,51.5257,-0.14499,,Cinder River,Alaska,United States,2347560,America/Anchorage,,Airports,,,,,,1,1
 RDB,67.75,-163.667,Red Dog,Red Dog,Alaska,United States,12799789,America/Anchorage,,Airports,,,,,PADG,1,2
 RDD,40.5056,-122.302,Redding Municipal Airport,Redding,California,United States,12521548,America/Los_Angeles,,Airports,,http://www.ci.redding.ca.us/adminsv/airports/index.htm,7003,502,KRDD,4,5
 RDM,44.2533,-121.162,Roberts Field Airport,Redmond,Oregon,United States,12521617,America/Los_Angeles,,Airports,,,7040,3077,KRDM,6,11


### PR DESCRIPTION
Fix an issue identified by @okryvorotko where the closest airport to London is actually a tiny regional airport in Alaska due to some very bad data. Removing it entirely.