### PR TITLE
Remove airports with few flights from stations db

### DIFF
--- a/airports.js
+++ b/airports.js
@@ -91,6 +91,11 @@ function loadAirports(callback) {
               // if( row[ 'name' ].trim() == '' ){
               //   continue;
               // }
+              // If our airport doesn't have enough carriers/flights, skip it
+              if ((row['type'] === 'Airports' || row['type'] === 'Other Airport') && row['direct_flights'] < 5 && row['carriers'] < 2) {
+                continue;
+              }
+
               /** Setup our location field */
               row['location'] = {
                 type: 'Point',


### PR DESCRIPTION
@jbrw1984 another one of these.

Currently our database contains many airports which aren't connected via any flights in Sabre. Trying to budget to these airports inevitably produces an error. This change culls out about 1/3rd of our airports, targeting those with extremely few flights/carrier. 

I asked in Slack for smaller airports which we wanted to be sure to include, and the list I received was (all remain):
- BUR
- YYJ
- YYC
- BRD
- OTH
- LAN

Examples of airports which were removed:
- KZB
- APF